### PR TITLE
Fix compilation error with current reflex versions

### DIFF
--- a/reflex-host.cabal
+++ b/reflex-host.cabal
@@ -1,5 +1,5 @@
 name:          reflex-host
-version:       0.2
+version:       0.3
 license:       BSD3
 license-file:  LICENSE
 cabal-version: >= 1.10
@@ -35,7 +35,7 @@ library
       base >= 4.4 && < 5
     , reducers >= 3.11
     , mtl
-    , reflex >= 0.3 && <0.5
+    , reflex >= 0.5 && <0.6
     , dlist
     , dependent-sum
     , transformers

--- a/reflex-host.cabal
+++ b/reflex-host.cabal
@@ -1,5 +1,5 @@
 name:          reflex-host
-version:       0.1
+version:       0.2
 license:       BSD3
 license-file:  LICENSE
 cabal-version: >= 1.10
@@ -35,7 +35,7 @@ library
       base >= 4.4 && < 5
     , reducers >= 3.11
     , mtl
-    , reflex >= 0.3
+    , reflex >= 0.3 && <0.5
     , dlist
     , dependent-sum
     , transformers

--- a/src/Reflex/Host/App.hs
+++ b/src/Reflex/Host/App.hs
@@ -38,11 +38,11 @@ import Prelude -- Silence AMP warnings
 -- does return 'Nothing' instead of an event trigger. This does not mean that it will
 -- neccessarily return Nothing on the next call too though.
 newEventWithConstructor
-  :: MonadAppHost t m => m (Event t a, a -> IO (Maybe (DSum (EventTrigger t))))
+  :: (MonadAppHost t m, Applicative f) => m (Event t a, a -> IO (Maybe (DSum (EventTrigger t) f)))
 newEventWithConstructor = do
   ref <- liftIO $ newIORef Nothing
   event <- newEventWithTrigger (\h -> writeIORef ref Nothing <$ writeIORef ref (Just h))
-  return (event, \a -> fmap (:=> a) <$> liftIO (readIORef ref))
+  return (event, \a -> fmap (:=> pure a) <$> liftIO (readIORef ref))
 
 -- | Create a new event from an external event source. The returned function can be used
 -- to fire the event.

--- a/src/Reflex/Host/App/Internal.hs
+++ b/src/Reflex/Host/App/Internal.hs
@@ -151,7 +151,9 @@ deriving instance ReflexHost t => Monad (AppHost t)
 
 -- | 'AppHost' supports hold
 instance ReflexHost t => MonadHold t (AppHost t) where
-  hold a0 = AppHost . lift . hold a0
+  hold            a b = AppHost $ lift $ hold a b
+  holdDyn         a b = AppHost $ lift $ holdDyn a b
+  holdIncremental a b = AppHost $ lift $ holdIncremental a b
 
 -- | 'AppHost' supports sample
 instance ReflexHost t => MonadSample t (AppHost t) where


### PR DESCRIPTION
See #4

Fix felt trivial enough. No testing done other than compilation. I did not fix the version bound (neither `reflex` nor `dependent-sum` provide a changelog and I am not in the mood to investigate).

`newEventWithConstructor` is probably more polymorphic than necessary (`f ~ Identity`).

I still don't know if I will make use of this library, and there is no implicit expectation for you to turn this PR into a proper package update.
