### PR TITLE
Add support for dynamic collection of widgets

### DIFF
--- a/reflex-host.cabal
+++ b/reflex-host.cabal
@@ -10,8 +10,8 @@ homepage:      http://github.com/bennofs/reflex-host/
 bug-reports:   http://github.com/bennofs/reflex-host/issues
 copyright:     Copyright (C) 2014 Benno Fünfstück
 synopsis:      Implementation support for reflex frameworks
-description:   
-  The reflex FRP library's functions for implementing a framework are quite lowlevel. 
+description:
+  The reflex FRP library's functions for implementing a framework are quite lowlevel.
   This library provides higher-level support for on top of the basic functions from reflex.
   It provides a monad with support for external event sources and performing IO actions in response to events.
 build-type:    Custom
@@ -33,6 +33,7 @@ library
   ghc-options: -Wall -fwarn-tabs
   build-depends:
       base >= 4.4 && < 5
+    , containers
     , reducers >= 3.11
     , mtl
     , reflex >= 0.5 && <0.6

--- a/src/Reflex/Host/App.hs
+++ b/src/Reflex/Host/App.hs
@@ -1,11 +1,12 @@
 {-# LANGUAGE TupleSections #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 -- | Module supporting the implementation of frameworks. You should import this if you
 -- want to build your own framework.
 module Reflex.Host.App
   ( hostApp
   , newEventWithConstructor, newExternalEvent
   , performEventAndTrigger_, performEvent_, performEvent
-  , switchAppHost, performAppHost, dynAppHost, holdAppHost
+  , switchAppHost, performAppHost, dynAppHost, holdAppHost, holdKeyAppHost
   , getPostBuild, performPostBuild, performEventAsync
   , MonadAppHost(..), AppHost()
   , AppInfo(..), infoPerform, infoQuit, infoFire, switchAppInfo
@@ -17,9 +18,11 @@ import Control.Monad
 import Control.Monad.Trans
 import Data.Dependent.Sum
 import Data.IORef
+import Data.Map.Strict (Map)
 import Data.Maybe
 import Data.Monoid
 import Reflex.Class
+import Reflex.Dynamic
 import Reflex.Host.App.Internal
 import Reflex.Host.Class
 
@@ -89,7 +92,7 @@ performEventAsync event = do
 -- more convenient to use.
 performPostBuild ::  (MonadAppHost t m) => HostFrame t a -> m (Event t a)
 performPostBuild action = do
-  (event, construct) <- newEventWithConstructor  
+  (event, construct) <- newEventWithConstructor
   performPostBuild_ $ do
     a <- action
     pure $ infoFire $ liftIO (F.foldMap pure <$> construct a)
@@ -152,3 +155,63 @@ holdAppHost mInit mChanged = do
   (postActions, aInit) <- runAppHost mInit
   aChanged <- switchAppHost postActions mChanged
   holdDyn aInit aChanged
+
+-- | Helper to execute host action in one step (instead of usual 3 steps)
+getRunWithPost :: MonadAppHost t m => m (m a -> HostFrame t (AppInfo t, a))
+getRunWithPost = do
+  run <- getRunAppHost
+  return $ run >=> \(post, a) -> (,a) <$> post
+
+-- | Mix in host action after an event fires. Only the 'AppInfo' of the
+-- currently active key-value pairs of application is registered. For example, 'performEvent'
+-- calls are only executed for the currently active application. As soon as it is
+-- switched out and replaced by a different application, they are no longer executed.
+--
+-- The first argument specifies the application that is used initially, before the
+-- event fires the first time.
+--
+-- Whenever a switch to a new host action happens, the returned dynamic is updated
+-- with current active key-value pairs.
+--
+-- The function is helpful for implementation of dynamic collections where addition
+-- or deletion of elements don't affect other parts of the collection. Each item
+-- of the key-value pair is constructed once and hence post build event is fired
+-- only once (or when you explicitly replaces an element with new one).
+holdKeyAppHost :: forall t m a k . (MonadAppHost t m, Ord k)
+  => Map k (m a) -- ^ Initial set of components
+  -> Event t (Map k (Maybe (m a))) -- ^ 'Nothing' values indicates that the key should be deleted, 'Just' indicates that the key should be added/replaced
+  -> m (Dynamic t (Map k a)) -- ^ Reflects current state of the collection.
+holdKeyAppHost initialMap event = do
+  -- describe how to execute partial updates
+  run <- getRunAppHost
+  postRun <- getRunWithPost
+  let
+    executedEvent :: Event t (Map k (Maybe (HostFrame t (AppInfo t, a))))
+    executedEvent = fmap (fmap postRun) <$> event
+
+    liftedEvent :: Event t (HostFrame t (Map k (Maybe (AppInfo t, a))))
+    liftedEvent = sequence . fmap sequence <$> executedEvent
+
+  -- execute partial updates to split values and app infos
+  updMap :: Event t (Map k (Maybe (AppInfo t, a))) <- performEvent liftedEvent
+  let
+    updInfoMap :: Event t (Map k (Maybe (AppInfo t)))
+    updInfoMap = fmap (fmap fst) <$> updMap
+
+    updValueMap :: Event t (Map k (Maybe a))
+    updValueMap = fmap (fmap snd) <$> updMap
+
+  -- construct initial values
+  initial :: Map k (HostFrame t (AppInfo t), a) <- liftHostFrame . sequence $ run <$> initialMap
+  let
+    initialInfo :: HostFrame t (Map k (AppInfo t))
+    initialInfo = sequence . fmap fst $ initial
+
+    initialValues :: Map k a
+    initialValues = fmap snd initial
+
+  -- register partial updates
+  performPostBuild_ $ flip switchKeyAppInfo updInfoMap =<< initialInfo
+
+  -- collect computed outputs
+  foldDyn updateMap initialValues updValueMap


### PR DESCRIPTION
Hi, this is an amazing library. I use it as a core for my game engine and I found a very sophisticated task during its developing. The task is creation a collection of components/widgets like `listHoldWithKey` function in `reflex-dom`, that meets the following criteria:

* Each component is created once at addition to the collection. Components haven't be recreated each time the collection is updated. One important clue of this that post build event is fired once for each widget.

* Feature of identifying parts of FRP network by keys, adding and removing the parts at will.

So, I have spent about a week to debug this code and tune it to be correct. Even if the PR isn't ever merged, one may find it helpful, I hope.

P.S. The demo game that is uses the `reflex-host` based engine (and the functions in the PR too): https://github.com/Teaspot-Studio/gore-and-ash-demo

