### PR TITLE
Compile under latest reflex

### DIFF
--- a/src/Reflex/Host/App/Internal.hs
+++ b/src/Reflex/Host/App/Internal.hs
@@ -210,6 +210,7 @@ instance ReflexHost t => MonadHold t (AppHost t) where
   hold            a b = AppHost $ lift $ hold a b
   holdDyn         a b = AppHost $ lift $ holdDyn a b
   holdIncremental a b = AppHost $ lift $ holdIncremental a b
+  buildDynamic    a b = AppHost $ lift $ buildDynamic a b
 
 -- | 'AppHost' supports sample
 instance ReflexHost t => MonadSample t (AppHost t) where

--- a/stack.yaml
+++ b/stack.yaml
@@ -4,9 +4,9 @@ packages:
 - '.'
 - location:
     git: https://github.com/reflex-frp/reflex
-    commit: 4eb436e0d94418c11e4c06be7fa982d59629c9a9
+    commit: a1092192c61f3dec924a8e2686dfe3440681bab3
   extra-dep: true
 extra-deps:
 - prim-uniq-0.1.0.1
 - ref-tf-0.4.0.1
-resolver: lts-7.16
+resolver: lts-8.22


### PR DESCRIPTION
Hi, this small fix allows to compile under current master of reflex. 

The patch fixes the following strange looking error:
``` 
[1 of 2] Compiling Reflex.Host.App.Internal ( src/Reflex/Host/App/Internal.hs, .stack-work/dist/x86_64-linux/Cabal-1.24.2.0/build/Reflex/Host/App/Internal.o )

/home/ncrashed/dev/dzuikov/reflex-host/src/Reflex/Host/App/Internal.hs:209:10: error:
    • Couldn't match kind ‘* -> *’ with ‘*’
      When matching the kind of ‘t’
    • In the expression: Reflex.Class.$dmbuildDynamic @t @AppHost t
      In an equation for ‘buildDynamic’:
          buildDynamic = Reflex.Class.$dmbuildDynamic @t @AppHost t
      In the instance declaration for ‘MonadHold t (AppHost t)’
    • Relevant bindings include
        buildDynamic :: PullM t a -> Event t a -> AppHost t (Dynamic t a)
          (bound at src/Reflex/Host/App/Internal.hs:209:10)
```