### PR TITLE
Fix missing headE implementation

### DIFF
--- a/src/Reflex/Host/App/Internal.hs
+++ b/src/Reflex/Host/App/Internal.hs
@@ -211,6 +211,7 @@ instance ReflexHost t => MonadHold t (AppHost t) where
   holdDyn         a b = AppHost $ lift $ holdDyn a b
   holdIncremental a b = AppHost $ lift $ holdIncremental a b
   buildDynamic    a b = AppHost $ lift $ buildDynamic a b
+  headE           a   = AppHost $ lift $ headE a
 
 -- | 'AppHost' supports sample
 instance ReflexHost t => MonadSample t (AppHost t) where

--- a/stack.yaml
+++ b/stack.yaml
@@ -4,9 +4,9 @@ packages:
 - '.'
 - location:
     git: https://github.com/reflex-frp/reflex
-    commit: a1092192c61f3dec924a8e2686dfe3440681bab3
+    commit: 60d2878142943487987feeeea108dbed5405f469
   extra-dep: true
 extra-deps:
 - prim-uniq-0.1.0.1
 - ref-tf-0.4.0.1
-resolver: lts-8.22
+resolver: lts-9.13


### PR DESCRIPTION
In latest reflex the `headE` is moved to `MonadHold` class, that causes runtime errors:
```
src/Reflex/Host/App/Internal.hs:209:10-48: No instance nor default method for class operation headE
```